### PR TITLE
Handle case where PROGRAM entry is unspecified

### DIFF
--- a/analyze_lsnr_log.py
+++ b/analyze_lsnr_log.py
@@ -46,9 +46,10 @@ for line in lsnrf:
 				line_datef = datetime.strptime(line_date,"%d-%b-%Y")
 				line_connectdata = line.split("*")[1]
 				line_address = line.split("*")[1]
-				data_search = re.search(r'PROGRAM=.[^\)]*', line_connectdata, re.M|re.I)
+				data_search = re.search(r'PROGRAM=[^\)]*', line_connectdata, re.M|re.I)
 				if data_search is not None:
 						line_prog = data_search.group().split("=")[1].split("\\")[-1]
+                                                if line_prog == "" : line_prog = "*UNSPECIFIED*"
 						if line_prog != "null":
 								try:
 										dict_program[line_datef,line_prog] += 1


### PR DESCRIPTION
In some cases, program name can be empty in the listener log. The
CONNECT_DATA clause will be similar to:

   (CONNECT_DATA=(CID=(PROGRAM=)(HOST=xxx.example.com)...

This was causing the script to mis-parse the program name, erroneously
identifying it as ")(HOST" rather than a missing value. The solution
chosen was to tag these items as "*UNSPECIFIED*" in the output.